### PR TITLE
Fixed sign errors in `euler_angles`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,9 +168,9 @@ where
     (
         cos_x_2 * cos_y_2 * cos_z_2 + sin_x_2 * sin_y_2 * sin_z_2,
         [
-            sin_x_2 * cos_y_2 * cos_z_2 + cos_x_2 * sin_y_2 * sin_z_2,
+            sin_x_2 * cos_y_2 * cos_z_2 - cos_x_2 * sin_y_2 * sin_z_2,
             cos_x_2 * sin_y_2 * cos_z_2 + sin_x_2 * cos_y_2 * sin_z_2,
-            cos_x_2 * cos_y_2 * sin_z_2 + sin_x_2 * sin_y_2 * cos_z_2,
+            cos_x_2 * cos_y_2 * sin_z_2 - sin_x_2 * sin_y_2 * cos_z_2,
         ],
     )
 }


### PR DESCRIPTION
The crate seems to follow the Euler angle conventions on [Wikipedia](https://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles). But the implementation given on Wikipedia uses negative signs in the formulas. The same formulas were used here, but with positive signs only. It looks like this is a mistake, since no other angle conventions can explain the formulas here.